### PR TITLE
fix queue channel size lowering when match is found

### DIFF
--- a/src/helpers/queueTimer.js
+++ b/src/helpers/queueTimer.js
@@ -13,7 +13,7 @@ module.exports = {
     }
 
     queueChannel.edit({
-      userLimit: 1
+      userLimit: config.players_per_match
     });
 
     setTimeout(() => {


### PR DESCRIPTION
Once the queue is full the count of the queue channel would lower to one. Made it use the number listed in the config file instead.